### PR TITLE
Add labeler configuration

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,16 @@
+frontend:
+  - 'src/**/*'
+  - 'public/**/*'
+
+workflow:
+  - '.github/workflows/*'
+
+config:
+  - 'package.json'
+  - 'tsconfig.json'
+  - 'rslib.config.ts'
+  - 'eslint.config.*'
+  - 'yarn.lock'
+
+docs:
+  - '**/*.md'


### PR DESCRIPTION
## Summary
- add `.github/labeler.yml` so the Labeler workflow can apply labels

## Testing
- `yarn lint` *(fails: '@typescript-eslint/no-unused-vars')*
- `yarn build` *(fails: DTS generation failure)*

------
https://chatgpt.com/codex/tasks/task_e_684364fe25c48326855d5f593ff7bbe5