### PR TITLE
Fix labeler issue permissions

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      issues: write
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- give labeler workflow permission to label issues

## Testing
- `yarn lint` *(fails: unused variables)*
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68474d67104483269c33b179370e7813