### PR TITLE
Fix README screenshot alt text

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 Orchard UI provides a set of custom strategies for Home Assistant dashboards. It supports various views, including home, floors, rooms, automations, lighting, and more, defined in the `strategies` folder.
 
-![Orchard UI Home ScreenshotI](./public/screenshot-home.png)
+![Orchard UI Home Screenshot](./public/screenshot-home.png)


### PR DESCRIPTION
## Summary
- correct screenshot alt text in README

## Testing
- `yarn lint` *(fails: unused vars in src)*
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6849d48547bc83269d48069057b45b37

## Summary by Sourcery

Documentation:
- Correct the alt text for the home screenshot in README.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a typo in the alt text of an image in the README file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->