### PR TITLE
Add HACS manifest and release build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Enable Corepack
+        run: corepack enable
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: yarn install --immutable
+      - run: yarn run build
+      - name: Upload artifact
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./dist/index.js
+          asset_name: orchard-ui.js
+          asset_content_type: application/javascript
+

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
+          cache: 'yarn'
       - run: yarn install --immutable
       - run: yarn run build
       - name: Upload artifact

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,7 @@
+{
+  "name": "Orchard UI",
+  "render_readme": true,
+  "filename": "dist/index.js",
+  "type": "plugin",
+  "description": "Custom strategies for Home Assistant dashboards."
+}

--- a/src/strategies/views/climate-view.ts
+++ b/src/strategies/views/climate-view.ts
@@ -26,12 +26,14 @@ export class ClimateViewStrategy extends ReactiveElement {
   }
 
   static async generateBadges(home: Home): Promise<LovelaceBadgeConfig[]> {
+    void home;
     return [];
   }
 
   static async generateSections(
     home: Home
   ): Promise<LovelaceSectionRawConfig[]> {
+    void home;
     return [];
   }
 }

--- a/src/strategies/views/floor-view.ts
+++ b/src/strategies/views/floor-view.ts
@@ -32,6 +32,8 @@ export class FloorViewStrategy extends ReactiveElement {
     config: FloorViewStrategyConfig,
     hass: Hass
   ): Promise<LovelaceBadgeConfig[]> {
+    void config;
+    void hass;
     return [];
   }
 
@@ -39,6 +41,8 @@ export class FloorViewStrategy extends ReactiveElement {
     config: FloorViewStrategyConfig,
     hass: Hass
   ): Promise<LovelaceSectionRawConfig[]> {
+    void config;
+    void hass;
     return [];
   }
 }

--- a/src/strategies/views/lights-view.ts
+++ b/src/strategies/views/lights-view.ts
@@ -27,6 +27,8 @@ export class LightsViewStrategy extends ReactiveElement {
     config: object,
     hass: Hass
   ): Promise<LovelaceBadgeConfig[]> {
+    void config;
+    void hass;
     return [];
   }
 
@@ -34,6 +36,8 @@ export class LightsViewStrategy extends ReactiveElement {
     config: object,
     hass: Hass
   ): Promise<LovelaceSectionRawConfig[]> {
+    void config;
+    void hass;
     return [];
   }
 }

--- a/src/strategies/views/room-view.ts
+++ b/src/strategies/views/room-view.ts
@@ -28,6 +28,8 @@ export class RoomViewStrategy extends ReactiveElement {
     config: RoomViewStrategyConfig,
     hass: Hass
   ): Promise<LovelaceBadgeConfig[]> {
+    void config;
+    void hass;
     return [];
   }
 
@@ -35,6 +37,8 @@ export class RoomViewStrategy extends ReactiveElement {
     config: RoomViewStrategyConfig,
     hass: Hass
   ): Promise<LovelaceSectionRawConfig[]> {
+    void config;
+    void hass;
     return [];
   }
 }

--- a/src/strategies/views/security-view.ts
+++ b/src/strategies/views/security-view.ts
@@ -24,6 +24,8 @@ export class SecurityViewStrategy extends ReactiveElement {
     config: object,
     hass: Hass
   ): Promise<LovelaceBadgeConfig[]> {
+    void config;
+    void hass;
     return [];
   }
 
@@ -31,6 +33,8 @@ export class SecurityViewStrategy extends ReactiveElement {
     config: object,
     hass: Hass
   ): Promise<LovelaceSectionRawConfig[]> {
+    void config;
+    void hass;
     return [];
   }
 }

--- a/src/strategies/views/speakers-tvs-view.ts
+++ b/src/strategies/views/speakers-tvs-view.ts
@@ -7,7 +7,7 @@ import {
 } from '../../lovelace';
 import { Hass } from '../../hass';
 
-type SpeakersTvsViewStrategyConfig = {};
+type SpeakersTvsViewStrategyConfig = Record<string, never>;
 
 export class SpeakersTvsViewStrategy extends ReactiveElement {
   static async generate(
@@ -26,6 +26,8 @@ export class SpeakersTvsViewStrategy extends ReactiveElement {
     config: SpeakersTvsViewStrategyConfig,
     hass: Hass
   ): Promise<LovelaceBadgeConfig[]> {
+    void config;
+    void hass;
     return [];
   }
 
@@ -33,6 +35,8 @@ export class SpeakersTvsViewStrategy extends ReactiveElement {
     config: SpeakersTvsViewStrategyConfig,
     hass: Hass
   ): Promise<LovelaceSectionRawConfig[]> {
+    void config;
+    void hass;
     return [];
   }
 }


### PR DESCRIPTION
## Summary
- add `hacs.json` manifest
- build and upload `dist/index.js` when a release is published

## Testing
- `yarn lint` *(fails: @typescript-eslint/no-unused-vars)*
- `yarn test`
- `yarn build`
- `act -j validate-hacs` *(fails: no Docker connection)*

------
https://chatgpt.com/codex/tasks/task_e_685250dfdc94832697333dd2b625ad3f

## Summary by Sourcery

Add HACS manifest and automate release artifact build and upload

New Features:
- Add `hacs.json` manifest for Home Assistant Community Store integration

CI:
- Introduce GitHub Actions workflow to build the project and upload `dist/index.js` as a release asset

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced automated release workflow to build and attach the project file as a release asset.
  - Added configuration for Home Assistant Community Store (HACS) integration, enabling easier installation and updates for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->