### PR TITLE
Add JSDoc to strategies

### DIFF
--- a/src/strategies/badges/climate-badge.ts
+++ b/src/strategies/badges/climate-badge.ts
@@ -1,7 +1,16 @@
 import { Entity } from '@smolpack/hasskit';
 import { LovelaceBadgeConfig } from '../../lovelace';
 
+/**
+ * Build a badge for climate entities like thermostats or fans.
+ */
 export class ClimateBadgeStrategy {
+  /**
+   * Create the Lovelace configuration for a climate badge.
+   *
+   * @param climateEntity - The entity representing the climate device.
+   * @returns The badge configuration.
+   */
   static async generate(climateEntity: Entity): Promise<LovelaceBadgeConfig> {
     return {
       type: 'entity',

--- a/src/strategies/badges/energy-badge.ts
+++ b/src/strategies/badges/energy-badge.ts
@@ -6,7 +6,10 @@ import { LovelaceBadgeConfig } from '../../lovelace';
  */
 export class EnergyBadgeStrategy {
   /**
-   * Builds the Lovelace badge configuration for energy usage.
+   * Build the Lovelace badge configuration for energy usage.
+   *
+   * @param co2SignalEntity - The entity that tracks CO₂ signal.
+   * @returns The badge configuration.
    */
   static async generate(co2SignalEntity: Entity): Promise<LovelaceBadgeConfig> {
     return {

--- a/src/strategies/badges/lights-badge.ts
+++ b/src/strategies/badges/lights-badge.ts
@@ -1,9 +1,18 @@
 import { LightEntity } from '@smolpack/hasskit';
 import { LovelaceBadgeConfig } from '../../lovelace';
 
+/**
+ * Build Lovelace badge configs for light entities.
+ */
 export class LightsBadgeStrategy {
+  /**
+   * Create a badge that displays a light entity.
+   *
+   * @param lightEntity - The light to render.
+   * @returns The badge configuration.
+   */
   static async generate(
-    lightEntity: LightEntity
+    lightEntity: LightEntity,
   ): Promise<LovelaceBadgeConfig> {
     return {
       type: 'entity',

--- a/src/strategies/badges/security-badge.ts
+++ b/src/strategies/badges/security-badge.ts
@@ -1,6 +1,16 @@
 import { Entity } from '@smolpack/hasskit';
 import { LovelaceBadgeConfig } from '../../lovelace';
+
+/**
+ * Generate badges for security related entities.
+ */
 export class SecurityBadgeStrategy {
+  /**
+   * Build the badge configuration for a lock or alarm entity.
+   *
+   * @param securityEntity - The security entity to display.
+   * @returns The generated badge configuration.
+   */
   static async generate(securityEntity: Entity): Promise<LovelaceBadgeConfig> {
     return {
       type: 'entity',

--- a/src/strategies/badges/speakers-tvs-badge.ts
+++ b/src/strategies/badges/speakers-tvs-badge.ts
@@ -1,9 +1,18 @@
 import { Entity } from '@smolpack/hasskit';
 import { LovelaceBadgeConfig } from '../../lovelace';
 
+/**
+ * Strategy for generating badges for speakers or televisions.
+ */
 export class SpeakersTvsBadgeStrategy {
+  /**
+   * Build the badge configuration for media player entities.
+   *
+   * @param mediaPlayerEntity - The media player to display.
+   * @returns The resulting badge configuration.
+   */
   static async generate(
-    mediaPlayerEntity: Entity
+    mediaPlayerEntity: Entity,
   ): Promise<LovelaceBadgeConfig> {
     return {
       type: 'entity',

--- a/src/strategies/badges/waste-badge.ts
+++ b/src/strategies/badges/waste-badge.ts
@@ -1,7 +1,16 @@
 import { Entity } from '@smolpack/hasskit';
 import { LovelaceBadgeConfig } from '../../lovelace';
 
+/**
+ * Display upcoming waste collection information.
+ */
 export class WasteBadgeStrategy {
+  /**
+   * Generate configuration for a waste entity badge.
+   *
+   * @param wasteEntity - The waste schedule entity.
+   * @returns The badge configuration.
+   */
   static async generate(wasteEntity: Entity): Promise<LovelaceBadgeConfig> {
     return {
       type: 'entity',

--- a/src/strategies/badges/weather-badge.ts
+++ b/src/strategies/badges/weather-badge.ts
@@ -1,7 +1,16 @@
 import { Entity } from '@smolpack/hasskit';
 import { LovelaceBadgeConfig } from '../../lovelace';
 
+/**
+ * Build a weather badge configuration.
+ */
 export class WeatherBadgeStrategy {
+  /**
+   * Generate a badge representing the weather entity.
+   *
+   * @param weatherEntity - The weather entity to display.
+   * @returns The badge configuration.
+   */
   static async generate(weatherEntity: Entity): Promise<LovelaceBadgeConfig> {
     return {
       type: 'entity',

--- a/src/strategies/cards/automation-card.ts
+++ b/src/strategies/cards/automation-card.ts
@@ -1,9 +1,18 @@
 import { AutomationEntity } from '@smolpack/hasskit';
 import { LovelaceCardConfig } from '../../lovelace';
 
+/**
+ * Display automations in a tile.
+ */
 export class AutomationCardStrategy {
+  /**
+   * Generate the automation tile configuration.
+   *
+   * @param automationEntity - The automation to show.
+   * @returns The Lovelace card configuration.
+   */
   static async generate(
-    automationEntity: AutomationEntity
+    automationEntity: AutomationEntity,
   ): Promise<LovelaceCardConfig> {
     return {
       type: 'tile',

--- a/src/strategies/cards/camera-card.ts
+++ b/src/strategies/cards/camera-card.ts
@@ -1,7 +1,16 @@
 import { Entity } from '@smolpack/hasskit';
 import { LovelaceCardConfig } from '../../lovelace';
 
+/**
+ * Strategy for rendering camera tiles.
+ */
 export class CameraCardStrategy {
+  /**
+   * Build a card for a camera entity.
+   *
+   * @param cameraEntity - The camera to display.
+   * @returns The Lovelace card configuration.
+   */
   static async generate(cameraEntity: Entity): Promise<LovelaceCardConfig> {
     return {
       type: 'picture-entity',

--- a/src/strategies/cards/climate-card.ts
+++ b/src/strategies/cards/climate-card.ts
@@ -4,7 +4,7 @@ import { LovelaceCardConfig } from '../../lovelace';
 /**
  * Render controls for climate devices.
  */
-export class ClimateCardStategy {
+export class ClimateCardStrategy {
   /**
    * Build a climate control card.
    *

--- a/src/strategies/cards/climate-card.ts
+++ b/src/strategies/cards/climate-card.ts
@@ -1,9 +1,18 @@
 import { ClimateEntity } from '@smolpack/hasskit';
 import { LovelaceCardConfig } from '../../lovelace';
 
+/**
+ * Render controls for climate devices.
+ */
 export class ClimateCardStategy {
+  /**
+   * Build a climate control card.
+   *
+   * @param climateEntity - The climate entity to control.
+   * @returns The Lovelace card configuration.
+   */
   static async generate(
-    climateEntity: ClimateEntity
+    climateEntity: ClimateEntity,
   ): Promise<LovelaceCardConfig> {
     return {
       type: 'tile',
@@ -14,8 +23,14 @@ export class ClimateCardStategy {
     };
   }
 
+  /**
+   * Build a list of features for the climate card.
+   *
+   * @param climateEntity - The climate entity to inspect.
+   * @returns The features to enable.
+   */
   static async generateFeatures(
-    climateEntity: ClimateEntity
+    climateEntity: ClimateEntity,
   ): Promise<object[]> {
     const features: object[] = [
       {

--- a/src/strategies/cards/floor-heading-card.ts
+++ b/src/strategies/cards/floor-heading-card.ts
@@ -5,7 +5,16 @@ import { LightsBadgeStrategy } from '../badges/lights-badge';
 import { SecurityBadgeStrategy } from '../badges/security-badge';
 import { SpeakersTvsBadgeStrategy } from '../badges/speakers-tvs-badge';
 
+/**
+ * Strategy for heading cards that introduce a floor.
+ */
 export class FloorHeadingCardStrategy {
+  /**
+   * Generate the heading card for a floor.
+   *
+   * @param floor - The floor to represent.
+   * @returns The card configuration.
+   */
   static async generate(floor: Floor): Promise<LovelaceCardConfig> {
     return {
       type: 'heading',
@@ -19,6 +28,12 @@ export class FloorHeadingCardStrategy {
     };
   }
 
+  /**
+   * Build floor level badges for the heading card.
+   *
+   * @param floor - The floor to render.
+   * @returns List of badges to show.
+   */
   static async generateBadges(floor: Floor): Promise<LovelaceBadgeConfig[]> {
     const promises = [];
 

--- a/src/strategies/cards/light-card.ts
+++ b/src/strategies/cards/light-card.ts
@@ -1,7 +1,16 @@
 import { LightEntity } from '@smolpack/hasskit';
 import { LovelaceCardConfig } from '../../lovelace';
 
+/**
+ * Build tiles for light controls.
+ */
 export class LightCardStrategy {
+  /**
+   * Generate a card for a light entity.
+   *
+   * @param lightEntity - The light to control.
+   * @returns The card configuration.
+   */
   static async generate(lightEntity: LightEntity): Promise<LovelaceCardConfig> {
     return {
       type: 'tile',
@@ -32,8 +41,14 @@ export class LightCardStrategy {
     };
   }
 
+  /**
+   * Determine which light features to expose.
+   *
+   * @param lightEntity - The light entity to inspect.
+   * @returns The feature list for the card.
+   */
   static async generateFeatures(
-    lightEntity: LightEntity
+    lightEntity: LightEntity,
   ): Promise<{ type: string }[]> {
     const features = [];
 

--- a/src/strategies/cards/security-card.ts
+++ b/src/strategies/cards/security-card.ts
@@ -1,7 +1,16 @@
 import { Entity } from '@smolpack/hasskit';
 import { LovelaceCardConfig } from '../../lovelace';
 
+/**
+ * Build a tile for lock entities.
+ */
 export class SecurityCardStrategy {
+  /**
+   * Create a card for a security lock.
+   *
+   * @param lockEntity - The lock or alarm entity.
+   * @returns The card configuration.
+   */
   static async generate(lockEntity: Entity): Promise<LovelaceCardConfig> {
     return {
       type: 'tile',

--- a/src/strategies/cards/speaker-tv-card.ts
+++ b/src/strategies/cards/speaker-tv-card.ts
@@ -1,9 +1,18 @@
 import { Entity } from '@smolpack/hasskit';
 import { LovelaceCardConfig } from '../../lovelace';
 
+/**
+ * Build tiles for media player control.
+ */
 export class SpeakerTvCardStrategy {
+  /**
+   * Create a tile for a speaker or TV entity.
+   *
+   * @param mediaPlayerEntity - The media player to render.
+   * @returns The card configuration.
+   */
   static async generate(
-    mediaPlayerEntity: Entity
+    mediaPlayerEntity: Entity,
   ): Promise<LovelaceCardConfig> {
     return {
       type: 'tile',

--- a/src/strategies/cards/switch-card.ts
+++ b/src/strategies/cards/switch-card.ts
@@ -1,7 +1,16 @@
 import { Entity } from '@smolpack/hasskit';
 import { LovelaceCardConfig } from '../../lovelace';
 
+/**
+ * Render a simple switch tile.
+ */
 export class SwitchCardStrategy {
+  /**
+   * Create a card for a switch entity.
+   *
+   * @param switchEntity - The switch to render.
+   * @returns The card configuration.
+   */
   static async generate(switchEntity: Entity): Promise<LovelaceCardConfig> {
     return {
       type: 'tile',

--- a/src/strategies/dashboards/floor-dashboard.ts
+++ b/src/strategies/dashboards/floor-dashboard.ts
@@ -17,10 +17,20 @@ type FloorDashboardStrategyConfigArea = {
   area_id?: string;
 };
 
+/**
+ * Strategy for dashboards that focus on a single floor.
+ */
 export class FloorDashboardStrategy extends ReactiveElement {
+  /**
+   * Build the dashboard configuration for one floor.
+   *
+   * @param config - The user provided config.
+   * @param hass - Home Assistant instance.
+   * @returns The Lovelace configuration object.
+   */
   static async generate(
     config: FloorDashboardStrategyConfig,
-    hass: Hass
+    hass: Hass,
   ): Promise<LovelaceConfig> {
     if (!config.floor_id) {
       return {
@@ -44,9 +54,16 @@ export class FloorDashboardStrategy extends ReactiveElement {
     };
   }
 
+  /**
+   * Create the views for each room on a floor.
+   *
+   * @param config - Floor and optional area configuration.
+   * @param hass - Home Assistant instance.
+   * @returns Array of view configurations.
+   */
   static async generateViews(
     config: FloorDashboardStrategyViewsConfig,
-    hass: Hass
+    hass: Hass,
   ): Promise<LovelaceViewRawConfig[]> {
     const floor = config.floor;
 

--- a/src/strategies/dashboards/home-dashboard.ts
+++ b/src/strategies/dashboards/home-dashboard.ts
@@ -9,12 +9,22 @@ import { DeepPartial } from '../../utils';
 
 export type HomeDashboardStrategyConfig = HomeViewStrategyConfig;
 
+/**
+ * Generate a multi-view dashboard for the entire home.
+ */
 export class HomeDashboardStrategy extends ReactiveElement {
   static logPrefix = `${NAME} - Home Dashboard Strategy`;
 
+  /**
+   * Build the Lovelace dashboard configuration.
+   *
+   * @param partialConfig - Optional override values.
+   * @param hass - The Home Assistant connection.
+   * @returns The final dashboard configuration.
+   */
   static async generate(
     partialConfig: DeepPartial<HomeDashboardStrategyConfig>,
-    hass: Hass
+    hass: Hass,
   ): Promise<LovelaceConfig> {
     const config = this.createConfig(partialConfig);
     const home = new Home(hass, config);
@@ -27,15 +37,28 @@ export class HomeDashboardStrategy extends ReactiveElement {
     };
   }
 
+  /**
+   * Normalize the input configuration.
+   *
+   * @param partialConfig - Config values supplied by the user.
+   * @returns The completed configuration object.
+   */
   static createConfig(
-    partialConfig: DeepPartial<HomeDashboardStrategyConfig>
+    partialConfig: DeepPartial<HomeDashboardStrategyConfig>,
   ): HomeDashboardStrategyConfig {
     return HomeViewStrategy.createConfig(partialConfig);
   }
 
+  /**
+   * Generate the dashboard views.
+   *
+   * @param home - The home representation.
+   * @param config - The processed configuration.
+   * @returns The view configurations.
+   */
   static async generateViews(
     home: Home,
-    config: HomeDashboardStrategyConfig
+    config: HomeDashboardStrategyConfig,
   ): Promise<LovelaceViewRawConfig[]> {
     const views = [
       {

--- a/src/strategies/sections/automations-section.ts
+++ b/src/strategies/sections/automations-section.ts
@@ -8,10 +8,20 @@ export type AutomationSectionStrategyConfig = {
   floor?: HassFloorRegistryEntry;
 };
 
+/**
+ * Display available automations grouped by area or floor.
+ */
 export class AutomationSectionStrategy {
+  /**
+   * Build the section configuration.
+   *
+   * @param home - The home instance.
+   * @param floor - Optional floor filter.
+   * @returns Lovelace section configuration.
+   */
   static async generate(
     home: Home,
-    floor?: Floor
+    floor?: Floor,
   ): Promise<LovelaceSectionRawConfig> {
     return {
       type: 'grid',
@@ -20,9 +30,16 @@ export class AutomationSectionStrategy {
     };
   }
 
+  /**
+   * Create the list of automation cards.
+   *
+   * @param home - The home instance.
+   * @param floor - Optional floor context.
+   * @returns List of card configs.
+   */
   static async generateCards(
     home: Home,
-    floor?: Floor
+    floor?: Floor,
   ): Promise<LovelaceCardConfig[]> {
     const cards: LovelaceCardConfig[] = [];
 

--- a/src/strategies/sections/cameras-section.ts
+++ b/src/strategies/sections/cameras-section.ts
@@ -3,10 +3,20 @@ import { LovelaceCardConfig, LovelaceSectionRawConfig } from '../../lovelace';
 import { CameraCardStrategy } from '../cards/camera-card';
 import { HomeViewStrategy } from '../views/home-view';
 
+/**
+ * Render a section listing all camera entities.
+ */
 export class CamerasSectionStrategy {
+  /**
+   * Build the camera section.
+   *
+   * @param home - The home representation.
+   * @param cameraEntities - List of camera entities to show.
+   * @returns Section configuration.
+   */
   static async generate(
     home: Home,
-    cameraEntities: Entity[]
+    cameraEntities: Entity[],
   ): Promise<LovelaceSectionRawConfig> {
     return {
       type: 'grid',
@@ -15,8 +25,14 @@ export class CamerasSectionStrategy {
     };
   }
 
+  /**
+   * Create the camera cards for the section.
+   *
+   * @param cameraEntities - Cameras to display.
+   * @returns Array of camera cards.
+   */
   static async generateCards(
-    cameraEntities: Entity[]
+    cameraEntities: Entity[],
   ): Promise<LovelaceCardConfig[]> {
     const cards: LovelaceCardConfig[] = [
       {

--- a/src/strategies/sections/floor-section.ts
+++ b/src/strategies/sections/floor-section.ts
@@ -7,7 +7,16 @@ import { SecurityCardStrategy } from '../cards/security-card';
 import { SpeakerTvCardStrategy } from '../cards/speaker-tv-card';
 import { SwitchCardStrategy } from '../cards/switch-card';
 
+/**
+ * Build a section summarizing an entire floor.
+ */
 export class FloorSectionStrategy {
+  /**
+   * Generate a Lovelace section for the provided floor.
+   *
+   * @param floor - Floor to render.
+   * @returns The section configuration.
+   */
   static async generate(floor: Floor): Promise<LovelaceSectionRawConfig> {
     return {
       type: 'grid',
@@ -15,6 +24,12 @@ export class FloorSectionStrategy {
     };
   }
 
+  /**
+   * Create all cards belonging to the floor section.
+   *
+   * @param floor - Floor context.
+   * @returns A list of cards.
+   */
   static async generateCards(floor: Floor): Promise<LovelaceCardConfig[]> {
     const promises = [FloorHeadingCardStrategy.generate(floor)];
 

--- a/src/strategies/sections/floor-section.ts
+++ b/src/strategies/sections/floor-section.ts
@@ -1,6 +1,6 @@
 import { ClimateEntity, Floor, LightEntity } from '@smolpack/hasskit';
 import { LovelaceCardConfig, LovelaceSectionRawConfig } from '../../lovelace';
-import { ClimateCardStategy } from '../cards/climate-card';
+import { ClimateCardStrategy } from '../cards/climate-card';
 import { FloorHeadingCardStrategy } from '../cards/floor-heading-card';
 import { LightCardStrategy } from '../cards/light-card';
 import { SecurityCardStrategy } from '../cards/security-card';
@@ -37,7 +37,7 @@ export class FloorSectionStrategy {
       for (const climateService of area.entitiesWithDomains([
         'climate',
       ]) as ClimateEntity[]) {
-        promises.push(ClimateCardStategy.generate(climateService));
+        promises.push(ClimateCardStrategy.generate(climateService));
       }
     }
 

--- a/src/strategies/views/automations-view.ts
+++ b/src/strategies/views/automations-view.ts
@@ -12,10 +12,20 @@ import { ConfigAreas, createConfigAreas } from '../../utils';
 
 export type AutomationsViewStrategyConfig = ConfigAreas;
 
+/**
+ * Show automations grouped by floor and area.
+ */
 export class AutomationsViewStrategy extends ReactiveElement {
+  /**
+   * Build the automations view.
+   *
+   * @param partialConfig - Partial configuration from the dashboard.
+   * @param hass - Home Assistant instance.
+   * @returns Lovelace view configuration.
+   */
   static async generate(
     partialConfig: AutomationsViewStrategyConfig,
-    hass: Hass
+    hass: Hass,
   ): Promise<LovelaceViewConfig> {
     const config = this.createConfig(partialConfig);
     const home = new Home(hass, config);
@@ -28,20 +38,37 @@ export class AutomationsViewStrategy extends ReactiveElement {
     return view;
   }
 
+  /**
+   * Normalize the automations view config.
+   *
+   * @param partialConfig - Partial configuration.
+   * @returns Completed configuration.
+   */
   static createConfig(
-    partialConfig: AutomationsViewStrategyConfig
+    partialConfig: AutomationsViewStrategyConfig,
   ): AutomationsViewStrategyConfig {
     return {
       ...createConfigAreas(partialConfig),
     };
   }
 
+  /**
+   * Currently there are no badges for the automations view.
+   *
+   * @returns Empty array of badges.
+   */
   static async generateBadges(): Promise<LovelaceBadgeConfig[]> {
     return [];
   }
 
+  /**
+   * Create automation sections for home and each floor.
+   *
+   * @param home - Home context.
+   * @returns Array of section configs.
+   */
   static async generateSections(
-    home: Home
+    home: Home,
   ): Promise<LovelaceSectionRawConfig[]> {
     const sections: LovelaceSectionRawConfig = [
       await AutomationSectionStrategy.generate(home),
@@ -54,6 +81,12 @@ export class AutomationsViewStrategy extends ReactiveElement {
     return sections;
   }
 
+  /**
+   * Determine column count for the view grid.
+   *
+   * @param home - Home context.
+   * @returns Number of columns.
+   */
   static maxColumns(home: Home): number {
     let maxColumns = 1;
 

--- a/src/strategies/views/climate-view.ts
+++ b/src/strategies/views/climate-view.ts
@@ -8,10 +8,20 @@ import {
 import { Hass } from '../../hass';
 import { Home } from '@smolpack/hasskit';
 
+/**
+ * View strategy for displaying climate devices.
+ */
 export class ClimateViewStrategy extends ReactiveElement {
+  /**
+   * Build the climate view configuration.
+   *
+   * @param config - View configuration object.
+   * @param hass - Home Assistant instance.
+   * @returns The view configuration.
+   */
   static async generate(
     config: object,
-    hass: Hass
+    hass: Hass,
   ): Promise<LovelaceViewConfig> {
     const home = new Home(hass);
 
@@ -25,13 +35,25 @@ export class ClimateViewStrategy extends ReactiveElement {
     };
   }
 
+  /**
+   * Generate badges for the climate view.
+   *
+   * @param home - Representation of the home.
+   * @returns Array of badge configs.
+   */
   static async generateBadges(home: Home): Promise<LovelaceBadgeConfig[]> {
     void home;
     return [];
   }
 
+  /**
+   * Build the sections for the climate view.
+   *
+   * @param home - Representation of the home.
+   * @returns Section configuration array.
+   */
   static async generateSections(
-    home: Home
+    home: Home,
   ): Promise<LovelaceSectionRawConfig[]> {
     void home;
     return [];

--- a/src/strategies/views/floor-view.ts
+++ b/src/strategies/views/floor-view.ts
@@ -11,10 +11,20 @@ type FloorViewStrategyConfig = {
   floor_id?: string;
 };
 
+/**
+ * Strategy for rendering a single floor view.
+ */
 export class FloorViewStrategy extends ReactiveElement {
+  /**
+   * Build the view representing one floor.
+   *
+   * @param config - View configuration.
+   * @param hass - Home Assistant instance.
+   * @returns The view configuration.
+   */
   static async generate(
     config: FloorViewStrategyConfig,
-    hass: Hass
+    hass: Hass,
   ): Promise<LovelaceViewConfig> {
     if (!config.floor_id) {
       return {};
@@ -28,18 +38,32 @@ export class FloorViewStrategy extends ReactiveElement {
     return view;
   }
 
+  /**
+   * Generate badges shown at the top of the floor view.
+   *
+   * @param config - View configuration.
+   * @param hass - Home Assistant instance.
+   * @returns Badge configuration array.
+   */
   static async generateBadges(
     config: FloorViewStrategyConfig,
-    hass: Hass
+    hass: Hass,
   ): Promise<LovelaceBadgeConfig[]> {
     void config;
     void hass;
     return [];
   }
 
+  /**
+   * Build the sections for the floor view.
+   *
+   * @param config - View configuration.
+   * @param hass - Home Assistant instance.
+   * @returns Section configuration array.
+   */
   static async generateSections(
     config: FloorViewStrategyConfig,
-    hass: Hass
+    hass: Hass,
   ): Promise<LovelaceSectionRawConfig[]> {
     void config;
     void hass;

--- a/src/strategies/views/home-view.ts
+++ b/src/strategies/views/home-view.ts
@@ -20,10 +20,20 @@ import { CamerasSectionStrategy } from '../sections/cameras-section';
 
 export type HomeViewStrategyConfig = ConfigAreas;
 
+/**
+ * Strategy for the main home view containing floors and system badges.
+ */
 export class HomeViewStrategy extends ReactiveElement {
+  /**
+   * Build the view configuration.
+   *
+   * @param config - User provided partial config.
+   * @param hass - Home Assistant connection.
+   * @returns The Lovelace view configuration.
+   */
   static async generate(
     config: DeepPartial<HomeViewStrategyConfig>,
-    hass: Hass
+    hass: Hass,
   ): Promise<LovelaceViewConfig> {
     const home = new Home(hass, this.createConfig(config));
 
@@ -38,14 +48,26 @@ export class HomeViewStrategy extends ReactiveElement {
     };
   }
 
+  /**
+   * Resolve defaults for the view configuration.
+   *
+   * @param partialConfig - Partial configuration.
+   * @returns Completed configuration.
+   */
   static createConfig(
-    partialConfig: DeepPartial<HomeViewStrategyConfig>
+    partialConfig: DeepPartial<HomeViewStrategyConfig>,
   ): HomeViewStrategyConfig {
     return {
       ...createConfigAreas(partialConfig),
     };
   }
 
+  /**
+   * Generate all badges shown on the home view.
+   *
+   * @param home - The home instance.
+   * @returns Array of badge configs.
+   */
   static async generateBadges(home: Home): Promise<LovelaceBadgeConfig[]> {
     const promises = [];
 
@@ -80,8 +102,14 @@ export class HomeViewStrategy extends ReactiveElement {
     return [...(await Promise.all(promises))];
   }
 
+  /**
+   * Generate the sections for each floor and camera group.
+   *
+   * @param home - Home context.
+   * @returns List of section configs.
+   */
   static async generateSections(
-    home: Home
+    home: Home,
   ): Promise<LovelaceSectionRawConfig[]> {
     const promises = [];
 
@@ -98,6 +126,12 @@ export class HomeViewStrategy extends ReactiveElement {
     return [...(await Promise.all(promises))];
   }
 
+  /**
+   * Determine the maximum number of columns allowed.
+   *
+   * @param floors - Floors within the home.
+   * @returns The number of columns.
+   */
   static maxColumns(floors: Floor[]): number {
     return Math.max(floors.length, 1);
   }

--- a/src/strategies/views/lights-view.ts
+++ b/src/strategies/views/lights-view.ts
@@ -7,10 +7,20 @@ import {
 } from '../../lovelace';
 import { Hass } from '../../hass';
 
+/**
+ * Render a view listing all lights.
+ */
 export class LightsViewStrategy extends ReactiveElement {
+  /**
+   * Build the lights view.
+   *
+   * @param config - View configuration object.
+   * @param hass - Home Assistant instance.
+   * @returns The Lovelace view configuration.
+   */
   static async generate(
     config: object,
-    hass: Hass
+    hass: Hass,
   ): Promise<LovelaceViewConfig> {
     const [badges, sections] = await Promise.all([
       this.generateBadges(config, hass),
@@ -23,18 +33,32 @@ export class LightsViewStrategy extends ReactiveElement {
     };
   }
 
+  /**
+   * Produce the badges for the lights view.
+   *
+   * @param config - View configuration object.
+   * @param hass - Home Assistant instance.
+   * @returns Array of badge configs.
+   */
   static async generateBadges(
     config: object,
-    hass: Hass
+    hass: Hass,
   ): Promise<LovelaceBadgeConfig[]> {
     void config;
     void hass;
     return [];
   }
 
+  /**
+   * Generate section configurations for the lights view.
+   *
+   * @param config - View configuration object.
+   * @param hass - Home Assistant instance.
+   * @returns List of section configs.
+   */
   static async generateSections(
     config: object,
-    hass: Hass
+    hass: Hass,
   ): Promise<LovelaceSectionRawConfig[]> {
     void config;
     void hass;

--- a/src/strategies/views/room-view.ts
+++ b/src/strategies/views/room-view.ts
@@ -11,10 +11,20 @@ type RoomViewStrategyConfig = {
   area_id?: string;
 };
 
+/**
+ * Strategy to show devices and information for a single room.
+ */
 export class RoomViewStrategy extends ReactiveElement {
+  /**
+   * Build the room view.
+   *
+   * @param config - Room view configuration.
+   * @param hass - Home Assistant instance.
+   * @returns Lovelace view configuration.
+   */
   static async generate(
     config: RoomViewStrategyConfig,
-    hass: Hass
+    hass: Hass,
   ): Promise<LovelaceViewConfig> {
     const view: LovelaceViewConfig = {
       badges: await this.generateBadges(config, hass),
@@ -24,18 +34,32 @@ export class RoomViewStrategy extends ReactiveElement {
     return view;
   }
 
+  /**
+   * Create badges for the room view.
+   *
+   * @param config - Room view configuration.
+   * @param hass - Home Assistant instance.
+   * @returns Array of badge configs.
+   */
   static async generateBadges(
     config: RoomViewStrategyConfig,
-    hass: Hass
+    hass: Hass,
   ): Promise<LovelaceBadgeConfig[]> {
     void config;
     void hass;
     return [];
   }
 
+  /**
+   * Build the sections for the room view.
+   *
+   * @param config - Room view configuration.
+   * @param hass - Home Assistant instance.
+   * @returns Section configuration list.
+   */
   static async generateSections(
     config: RoomViewStrategyConfig,
-    hass: Hass
+    hass: Hass,
   ): Promise<LovelaceSectionRawConfig[]> {
     void config;
     void hass;

--- a/src/strategies/views/security-view.ts
+++ b/src/strategies/views/security-view.ts
@@ -7,10 +7,20 @@ import {
 } from '../../lovelace';
 import { Hass } from '../../hass';
 
+/**
+ * View strategy displaying security devices.
+ */
 export class SecurityViewStrategy extends ReactiveElement {
+  /**
+   * Build the security view configuration.
+   *
+   * @param config - View configuration object.
+   * @param hass - Home Assistant instance.
+   * @returns The Lovelace view configuration.
+   */
   static async generate(
     config: object,
-    hass: Hass
+    hass: Hass,
   ): Promise<LovelaceViewConfig> {
     const view: LovelaceViewConfig = {
       badges: await this.generateBadges(config, hass),
@@ -20,18 +30,32 @@ export class SecurityViewStrategy extends ReactiveElement {
     return view;
   }
 
+  /**
+   * Create badges for the security view.
+   *
+   * @param config - View configuration object.
+   * @param hass - Home Assistant instance.
+   * @returns Array of badge configs.
+   */
   static async generateBadges(
     config: object,
-    hass: Hass
+    hass: Hass,
   ): Promise<LovelaceBadgeConfig[]> {
     void config;
     void hass;
     return [];
   }
 
+  /**
+   * Build sections for the security view.
+   *
+   * @param config - View configuration object.
+   * @param hass - Home Assistant instance.
+   * @returns Section configuration list.
+   */
   static async generateSections(
     config: object,
-    hass: Hass
+    hass: Hass,
   ): Promise<LovelaceSectionRawConfig[]> {
     void config;
     void hass;

--- a/src/strategies/views/speakers-tvs-view.ts
+++ b/src/strategies/views/speakers-tvs-view.ts
@@ -9,10 +9,20 @@ import { Hass } from '../../hass';
 
 type SpeakersTvsViewStrategyConfig = Record<string, never>;
 
+/**
+ * View strategy for all speaker and TV entities.
+ */
 export class SpeakersTvsViewStrategy extends ReactiveElement {
+  /**
+   * Build the speakers and TVs view.
+   *
+   * @param config - View configuration object.
+   * @param hass - Home Assistant instance.
+   * @returns The Lovelace view configuration.
+   */
   static async generate(
     config: SpeakersTvsViewStrategyConfig,
-    hass: Hass
+    hass: Hass,
   ): Promise<LovelaceViewConfig> {
     const view: LovelaceViewConfig = {
       badges: await this.generateBadges(config, hass),
@@ -22,18 +32,32 @@ export class SpeakersTvsViewStrategy extends ReactiveElement {
     return view;
   }
 
+  /**
+   * Create badges for the speakers and TVs view.
+   *
+   * @param config - View configuration object.
+   * @param hass - Home Assistant instance.
+   * @returns Array of badge configs.
+   */
   static async generateBadges(
     config: SpeakersTvsViewStrategyConfig,
-    hass: Hass
+    hass: Hass,
   ): Promise<LovelaceBadgeConfig[]> {
     void config;
     void hass;
     return [];
   }
 
+  /**
+   * Generate sections for the speakers and TVs view.
+   *
+   * @param config - View configuration object.
+   * @param hass - Home Assistant instance.
+   * @returns Section configuration list.
+   */
   static async generateSections(
     config: SpeakersTvsViewStrategyConfig,
-    hass: Hass
+    hass: Hass,
   ): Promise<LovelaceSectionRawConfig[]> {
     void config;
     void hass;


### PR DESCRIPTION
## Summary
- document exported strategy classes and methods with JSDoc
- run linter to verify formatting

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68527461c5948326b325c3cad2956ab2

## Summary by Sourcery

Document and add JSDoc comments to exported classes and their methods across strategies, views, dashboards, sections, cards, and badges, and run the linter to enforce consistent code formatting.

Enhancements:
- Add JSDoc comments to public classes and methods throughout view, dashboard, section, card, and badge strategies.

Chores:
- Run the linter to verify and enforce code formatting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive documentation comments to all strategy classes and their public methods, improving code clarity and maintainability. No changes were made to functionality or user-facing behaviour.  
  - Corrected minor class name typos for improved accuracy in documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->