### PR TITLE
Add unit tests for strategies

### DIFF
--- a/src/strategies/dashboards/floor-dashboard.test.ts
+++ b/src/strategies/dashboards/floor-dashboard.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'vitest';
+import { CUSTOM_ELEMENT_NAME } from '../../config';
+import { FloorDashboardStrategy } from './floor-dashboard';
+
+const hass = {
+  floors: {
+    f1: { floor_id: 'f1', icon: 'mdi:home-floor-1' },
+  },
+  areas: {
+    a1: { area_id: 'a1', floor_id: 'f1', name: 'Kitchen' },
+    a2: { area_id: 'a2', floor_id: 'f1', name: 'Living' },
+  },
+} as any;
+
+describe('FloorDashboardStrategy.generate', () => {
+  test('returns views for a given floor', async () => {
+    const config = await FloorDashboardStrategy.generate({ floor_id: 'f1' }, hass);
+
+    expect(config).toEqual({
+      views: [
+        {
+          type: 'sections',
+          title: 'f1',
+          path: 'f1',
+          icon: 'mdi:home-floor-1',
+          max_columns: 2,
+          strategy: { type: `custom:${CUSTOM_ELEMENT_NAME}-floor`, floor_id: 'f1' },
+        },
+        {
+          type: 'sections',
+          title: 'Kitchen',
+          path: 'a1',
+          strategy: { type: `custom:${CUSTOM_ELEMENT_NAME}-room`, area_id: 'a1' },
+        },
+        {
+          type: 'sections',
+          title: 'Living',
+          path: 'a2',
+          strategy: { type: `custom:${CUSTOM_ELEMENT_NAME}-room`, area_id: 'a2' },
+        },
+      ],
+    });
+  });
+});

--- a/src/strategies/dashboards/home-dashboard.test.ts
+++ b/src/strategies/dashboards/home-dashboard.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
+import { CUSTOM_ELEMENT_NAME } from '../../config';
+import { AutomationsViewStrategy } from '../views/automations-view';
+import { HomeViewStrategy } from '../views/home-view';
+
+vi.mock('@smolpack/hasskit', () => ({
+  Home: class {
+    zones = [{}];
+    climateEntity = { icon: 'mdi:thermostat' };
+    lightEntity = { icon: 'mdi:lightbulb' };
+    lockEntity = { icon: 'mdi:lock' };
+    mediaPlayerEntity = { icon: 'mdi:television' };
+    constructor(_hass: unknown, _config?: unknown) {}
+  },
+}));
+
+import { HomeDashboardStrategy } from './home-dashboard';
+
+describe('HomeDashboardStrategy.generate', () => {
+  beforeEach(() => {
+    vi.spyOn(AutomationsViewStrategy, 'maxColumns').mockReturnValue(3);
+    vi.spyOn(HomeViewStrategy, 'maxColumns').mockReturnValue(2);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('returns a dashboard config with expected views', async () => {
+    const hass = {} as unknown;
+    const config = await HomeDashboardStrategy.generate({}, hass as any);
+
+    expect(config).toEqual({
+      views: [
+        {
+          type: 'sections',
+          title: 'Home',
+          path: 'home',
+          icon: 'mdi:home',
+          max_columns: 2,
+          strategy: {
+            type: `custom:${CUSTOM_ELEMENT_NAME}-home`,
+            areas: [],
+          },
+        },
+        {
+          type: 'sections',
+          title: 'Automations',
+          icon: 'mdi:alarm',
+          max_columns: 3,
+          strategy: {
+            type: `custom:${CUSTOM_ELEMENT_NAME}-automations`,
+            areas: [],
+          },
+        },
+        {
+          type: 'sections',
+          title: 'Climate',
+          path: 'climate',
+          icon: 'mdi:thermostat',
+          strategy: {
+            type: `custom:${CUSTOM_ELEMENT_NAME}-climate`,
+            areas: [],
+          },
+        },
+        {
+          type: 'sections',
+          title: 'Lights',
+          path: 'lights',
+          icon: 'mdi:lightbulb',
+          strategy: {
+            type: `custom:${CUSTOM_ELEMENT_NAME}-lights`,
+            areas: [],
+          },
+        },
+        {
+          type: 'sections',
+          title: 'Security',
+          path: 'security',
+          icon: 'mdi:lock',
+          strategy: {
+            type: `custom:${CUSTOM_ELEMENT_NAME}-security`,
+            areas: [],
+          },
+        },
+        {
+          type: 'sections',
+          title: 'Speakers & TVs',
+          path: 'speakers-tvs',
+          icon: 'mdi:television',
+          strategy: {
+            type: `custom:${CUSTOM_ELEMENT_NAME}-speakers-tvs`,
+            areas: [],
+          },
+        },
+      ],
+    });
+  });
+});

--- a/src/strategies/views/automations-view.test.ts
+++ b/src/strategies/views/automations-view.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test, vi } from 'vitest';
+
+vi.mock('@smolpack/hasskit', () => ({
+  Home: class {
+    floors = [];
+    constructor(_hass: unknown, _config?: unknown) {}
+    entitiesWithDomains() { return []; }
+  },
+}));
+
+import { AutomationsViewStrategy } from './automations-view';
+import { AutomationSectionStrategy } from '../sections/automations-section';
+
+describe('AutomationsViewStrategy.generate', () => {
+  test('returns a view with one automation section', async () => {
+    vi.spyOn(AutomationSectionStrategy, 'generate').mockResolvedValue({ type: 'grid', cards: [] });
+
+    const view = await AutomationsViewStrategy.generate({ areas: [] }, {} as any);
+
+    expect(view).toEqual({ badges: [], sections: [{ type: 'grid', cards: [] }] });
+  });
+});

--- a/src/strategies/views/climate-view.test.ts
+++ b/src/strategies/views/climate-view.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test, vi } from 'vitest';
+
+vi.mock('@smolpack/hasskit', () => ({
+  Home: class {
+    constructor(_hass: unknown) {}
+  },
+}));
+
+import { ClimateViewStrategy } from './climate-view';
+
+describe('ClimateViewStrategy.generate', () => {
+  test('returns empty climate view', async () => {
+    const view = await ClimateViewStrategy.generate({}, {} as any);
+    expect(view).toEqual({ badges: [], sections: [] });
+  });
+});

--- a/src/strategies/views/floor-view.test.ts
+++ b/src/strategies/views/floor-view.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from 'vitest';
+import { FloorViewStrategy } from './floor-view';
+
+describe('FloorViewStrategy.generate', () => {
+  test('returns empty object when no floor_id is provided', async () => {
+    const view = await FloorViewStrategy.generate({}, {} as any);
+    expect(view).toEqual({});
+  });
+});

--- a/src/strategies/views/home-view.test.ts
+++ b/src/strategies/views/home-view.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test, vi } from 'vitest';
+
+vi.mock('@smolpack/hasskit', () => ({
+  Home: class {
+    floors = [];
+    weatherEntity = undefined;
+    climateEntity = undefined;
+    lightEntity = undefined;
+    lockEntity = undefined;
+    mediaPlayerEntity = undefined;
+    co2SignalEntity = undefined;
+    wasteEntity = undefined;
+    constructor(_hass: unknown, _config?: unknown) {}
+    entitiesWithDomains() { return []; }
+  },
+  Floor: class {},
+}));
+
+import { HomeViewStrategy } from './home-view';
+
+describe('HomeViewStrategy.generate', () => {
+  test('returns empty badges and sections when no entities', async () => {
+    const config = await HomeViewStrategy.generate({}, {} as any);
+    expect(config).toEqual({ badges: [], sections: [] });
+  });
+
+  test('maxColumns equals number of floors', () => {
+    expect(HomeViewStrategy.maxColumns([{}, {}] as any)).toBe(2);
+  });
+});

--- a/src/strategies/views/lights-view.test.ts
+++ b/src/strategies/views/lights-view.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from 'vitest';
+import { LightsViewStrategy } from './lights-view';
+
+describe('LightsViewStrategy.generate', () => {
+  test('returns empty lights view', async () => {
+    const view = await LightsViewStrategy.generate({}, {} as any);
+    expect(view).toEqual({ badges: [], sections: [] });
+  });
+});

--- a/src/strategies/views/room-view.test.ts
+++ b/src/strategies/views/room-view.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from 'vitest';
+import { RoomViewStrategy } from './room-view';
+
+describe('RoomViewStrategy.generate', () => {
+  test('returns view with empty lists', async () => {
+    const view = await RoomViewStrategy.generate({}, {} as any);
+    expect(view).toEqual({ badges: [], sections: [] });
+  });
+});

--- a/src/strategies/views/security-view.test.ts
+++ b/src/strategies/views/security-view.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from 'vitest';
+import { SecurityViewStrategy } from './security-view';
+
+describe('SecurityViewStrategy.generate', () => {
+  test('returns empty security view', async () => {
+    const view = await SecurityViewStrategy.generate({}, {} as any);
+    expect(view).toEqual({ badges: [], sections: [] });
+  });
+});

--- a/src/strategies/views/speakers-tvs-view.test.ts
+++ b/src/strategies/views/speakers-tvs-view.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from 'vitest';
+import { SpeakersTvsViewStrategy } from './speakers-tvs-view';
+
+describe('SpeakersTvsViewStrategy.generate', () => {
+  test('returns empty speakers & TVs view', async () => {
+    const view = await SpeakersTvsViewStrategy.generate({}, {} as any);
+    expect(view).toEqual({ badges: [], sections: [] });
+  });
+});


### PR DESCRIPTION
## Summary
- add dashboard strategy tests
- add view strategy tests for each exported component

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68528b67cdec832691d185f9f373918b

## Summary by Sourcery

Add comprehensive unit tests for dashboard and view strategy modules

Tests:
- Add unit test for FloorDashboardStrategy.generate to verify view configurations
- Create test files for home-dashboard and all view strategies (automations, climate, floor, home, lights, room, security, speakers-tvs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added comprehensive test suites for dashboard and view generation strategies, including Floor, Home, Automations, Climate, Lights, Security, Speakers & TVs, Room, and Floor views.
  - Verified that generated configurations and views return the expected structure, including correct handling of empty or default input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->