### PR TITLE
Fix automations sections type

### DIFF
--- a/src/strategies/views/automations-view.ts
+++ b/src/strategies/views/automations-view.ts
@@ -1,4 +1,5 @@
 import { ReactiveElement } from 'lit';
+import { Home } from '@smolpack/hasskit';
 import { CUSTOM_ELEMENT_NAME } from '../../config';
 import {
   LovelaceBadgeConfig,
@@ -7,7 +8,6 @@ import {
 } from '../../lovelace';
 import { Hass } from '../../hass';
 import { AutomationSectionStrategy } from '../sections/automations-section';
-import { Home } from '@smolpack/hasskit';
 import { ConfigAreas, createConfigAreas } from '../../utils';
 
 export type AutomationsViewStrategyConfig = ConfigAreas;
@@ -70,7 +70,7 @@ export class AutomationsViewStrategy extends ReactiveElement {
   static async generateSections(
     home: Home,
   ): Promise<LovelaceSectionRawConfig[]> {
-    const sections: LovelaceSectionRawConfig = [
+    const sections: LovelaceSectionRawConfig[] = [
       await AutomationSectionStrategy.generate(home),
     ];
 


### PR DESCRIPTION
## Summary
- type the sections array correctly
- reorder automations view imports

## Testing
- `yarn lint` *(fails: package not present in lockfile)*
- `yarn test` *(fails: package not present in lockfile)*
- `yarn run build` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_685d2f41c4d08326aa7b7649e8c5cc70

## Summary by Sourcery

Fix type annotation for sections array in the automations view and clean up imports

Bug Fixes:
- Correct sections variable type from LovelaceSectionRawConfig to an array of that type

Enhancements:
- Remove unused Home import from automations view

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code structure and corrected type annotations for better consistency and maintainability. No visible changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->